### PR TITLE
Update config.schema.json

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -71,7 +71,7 @@
                                         "type": "boolean"
                                     },
                                     "maxActivations": {
-                                        "title": "Maxium number of activations per period",
+                                        "title": "Maximum number of activations per period",
                                         "type": "integer"
                                     }
                                 }


### PR DESCRIPTION
Correcting a small typo: 'Maxium' should be 'Maximum' on the title for active periods.